### PR TITLE
Allow nested `something`s

### DIFF
--- a/lib/chai-things.js
+++ b/lib/chai-things.js
@@ -14,23 +14,33 @@
 
   var Assertion = chai.Assertion,
       assertionPrototype = Assertion.prototype,
-      expect = chai.expect;
+      expect = chai.expect,
+      containPropertyDesc = Object.getOwnPropertyDescriptor(assertionPrototype, 'contain');
+  Object.defineProperty(assertionPrototype, 'contains', containPropertyDesc);
+  Object.defineProperty(assertionPrototype, 'includes', containPropertyDesc);
 
   // Handles the `something` chain property
   function chainSomething() {
     // `include` or `contains` should have been called before
     if (!utils.flag(this, "contains"))
       throw new Error("cannot use something without include or contains");
-    // `something` should not have been used already
-    if (utils.flag(this, "something"))
-      throw new Error("cannot use something twice in an assertion");
     // flag that this is a `something` chain
-    utils.flag(this, "something", {
-      // remember if `something` was negated
-      negate: utils.flag(this, "negate")
-    });
-    // reset the negation flag for the coming assertion
-    utils.flag(this, "negate", false);
+    var lastSomething = this, newSomething = {};
+    while (utils.flag(lastSomething, "something")) {
+      lastSomething = utils.flag(lastSomething, "something");
+    }
+    // Transfer all the flags to the new `something`
+    utils.transferFlags(this, newSomething, false);
+    // Removing them from `this` in the process.
+    for (var prop in this.__flags) {
+      if (prop != 'something' && prop != 'object' && prop != 'ssfi' && prop != 'message') {
+        delete this.__flags[prop];
+      }
+    }
+    // And add the `newSomething` to the `lastSomething` in the chain.
+    utils.flag(lastSomething, "something", newSomething);
+    // And then clear the `something` flag from `newSomething`.
+    utils.flag(newSomething, "something", false);
   }
 
   // Performs the `something()` assertion
@@ -38,7 +48,8 @@
     // Undo the flags set by the `something` chain property
     var somethingFlags = utils.flag(this, "something");
     utils.flag(this, "something", false);
-    utils.flag(this, "negate", somethingFlags.negate);
+    if (somethingFlags)
+      utils.transferFlags(somethingFlags, this, true);
 
     // The assertion's object for `something` should be array-like
     var object = utils.flag(this, "object");
@@ -62,13 +73,13 @@
   // Override all methods to react on a possible `something` in the chain
   methodNames.forEach(function (methodName) {
     Assertion.overwriteMethod(methodName, function (_super) {
-      return function () {
+      var thisFunc = function () {
         // Return if no `something` has been used in the chain
         var somethingFlags = utils.flag(this, "something");
         if (!somethingFlags)
           return _super.apply(this, arguments);
-        // Clear the `something` flag; it should not be handled again
-        utils.flag(this, "something", false);
+        // Use the nested `something` flag as the new `something` flag for this.
+        utils.flag(this, "something", utils.flag(somethingFlags, "something"));
 
         // The assertion's object for `something` should be array-like
         var arrayObject = utils.flag(this, "object");
@@ -77,7 +88,7 @@
         expect(length).to.be.a("number", "something object length");
 
         // In the negative case, an empty array means success
-        var negate = somethingFlags.negate;
+        var negate = utils.flag(somethingFlags, "negate");
         if (negate && !length)
           return;
         // In the positive case, the array should not be empty
@@ -91,17 +102,19 @@
           var item = arrayObject[i],
               itemAssertion = copyAssertion(this, item, somethingAssert);
           assertionError = null;
-          try { _super.apply(itemAssertion, arguments); }
+          try { thisFunc.apply(itemAssertion, arguments); }
           catch (error) { assertionError = error; }
           // If the element satisfies the assertion
           if (!assertionError) {
             // In case the base assertion is negated, a satisfying element
             // means the base assertion ("no element must satisfy x") fails
             if (negate) {
-              // Assert the negated item assertion, which should fail and throw an error
-              var negItemAssertion = copyAssertion(this, item, somethingAssert, true);
-              _super.apply(negItemAssertion, arguments);
-              // Throw here if, for some reason, the negated item assertion didn't throw
+              if (!utils.flag(somethingFlags, "something")) {
+                // If we have no child `something`s then assert the negated item assertion, which should fail and throw an error
+                var negItemAssertion = copyAssertion(this, item, somethingAssert, true);
+                thisFunc.apply(negItemAssertion, arguments);
+              }
+              // Throw here if we have a child `something`, or, for some reason, the negated item assertion didn't throw
               new Assertion(arrayObject).assert(false,
                   "expected no element of #{this} to satisfy the assertion");
             }
@@ -122,6 +135,7 @@
         if (!negate)
           throw assertionError;
       };
+      return thisFunc;
     });
   });
 

--- a/test/something.coffee
+++ b/test/something.coffee
@@ -7,11 +7,6 @@ describe "using something", ->
       (() -> [].should.something.that.deep.equals 1).
         should.throw "cannot use something without include or contains"
 
-  describe "when something has already been used", ->
-    it "should throw an error", ->
-      (() -> [].should.include.something.that.something).
-        should.throw "cannot use something twice in an assertion"
-
 
 describe "using something()", ->
 
@@ -130,6 +125,20 @@ describe "the array [{ a: 1 }, { a: 1 }]", ->
   it "does not *not* include something that deep equals { a: 1 }", ->
     (() -> array.should.not.include.something.that.deep.equals { a: 1 }).
       should.throw "expected no element of [ { a: 1 }, { a: 1 } ] to deeply equal { a: 1 }"
+
+
+describe "the array [[{ a: 1 }, { a: 1 }]]", ->
+  array = [[{ a: 1 }, { a: 1 }]]
+
+  it "should include something that includes something that deep equals { a: 1 }", ->
+    array.should.include.something.that.includes.something.that.deep.equals { a: 1 }
+
+  it "should not include something that not deep equals { a: 1 }", ->
+    array.should.not.include.something.that.includes.something.that.not.deep.equals { a: 1 }
+
+  it "does not *not* include something that deep equals { a: 1 }", ->
+    (() -> array.should.not.include.something.that.includes.something.that.deep.equals { a: 1 }).
+      should.throw "expected no element of [ [ { a: 1 }, { a: 1 } ] ] to satisfy the assertion"
 
 
 describe "the string 'abcde'", ->


### PR DESCRIPTION
Allow nesting `something` in the chain, eg. `[['a']].should.include.something.that.includes.something.that.equals('a')`
