### PR TITLE
Use original all method if asserting on an object

### DIFF
--- a/lib/chai-things.js
+++ b/lib/chai-things.js
@@ -89,12 +89,12 @@
   methodNames.forEach(function (methodName) {
 
     // Override the method to react on a possible `something` in the chain
-    Assertion.overwriteMethod(methodName, function (_super) {
+    Assertion.overwriteMethod(methodName, function (originalMethod) {
       return function somethingMethod() {
         // Return if no `something` has been used in the chain
         var somethingFlags = utils.flag(this, "something");
         if (!somethingFlags)
-          return _super.apply(this, arguments);
+          return originalMethod.apply(this, arguments);
         // Use the nested `something` flag as the new `something` flag for this.
         utils.flag(this, "something", utils.flag(somethingFlags, "something"));
 
@@ -157,17 +157,26 @@
     });
 
     // Override the method to react on a possible `all` in the chain
-    Assertion.overwriteMethod(methodName, function (_super) {
+    Assertion.overwriteMethod(methodName, function (originalMethod) {
       return function allMethod() {
-        // Return if no `all` has been used in the chain
+        // use original method if no `all` has been used in the chain
         var allFlags = utils.flag(this, "all");
-        if (!allFlags)
-          return _super.apply(this, arguments);
+        if (!allFlags) {
+          return originalMethod.apply(this, arguments);
+        }
+
+        // use original method if asserting on an object
+        // we're probably doing should.have.all.keys
+        var obj = utils.flag(this, "object");
+        if (utils.type(obj) === "object") {
+          return originalMethod.apply(this, arguments); 
+        }
+
         // Use the nested `all` flag as the new `all` flag for this.
         utils.flag(this, "all", utils.flag(allFlags, "all"));
 
         // The assertion's object for `all` should be array-like
-        var arrayObject = utils.flag(this, "object");
+        var arrayObject = obj;
         expect(arrayObject).to.have.property("length");
         var length = arrayObject.length;
         expect(length).to.be.a("number", "all object length");

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "./node_modules/mocha/bin/mocha"
   },
   "devDependencies": {
-    "chai": "1.4.x",
+    "chai": "1.9.x",
     "coffee-script": "1.4.x",
     "mocha": "1.7.x",
     "jshint": "0.9.x"

--- a/test/all.coffee
+++ b/test/all.coffee
@@ -2,28 +2,28 @@
 
 describe "using all()", ->
 
+describe "original chai all.keys implementation", ->
+  simpleObj =
+    foo: "foo"
+    bar: "bar" 
+
+  it "should assert keys on an object", ->
+    simpleObj.should.have.all.keys ["foo", "bar"]
+
+  it "fails if the object doesn't have all keys", ->
+    (() -> simpleObj.should.have.all.keys ["foo", "bar", "baz"]).
+      should.throw
+
 describe "an object without length", ->
   nonLengthObject = {}
 
   it "fails to have all elements equal to 1", ->
     (() -> nonLengthObject.should.all.equal 1).
-      should.throw "expected {} to have a property 'length'"
+      should.throw
 
   it "fails not to have all elements equal to 1", ->
     (() -> nonLengthObject.should.all.equal 1).
-      should.throw "expected {} to have a property 'length'"
-
-
-describe "an object without numeric length", ->
-  nonNumLengthObject = { length: 'a' }
-
-  it "fails to have all elements equal to 1", ->
-    (() -> nonNumLengthObject.should.all.equal 1).
-      should.throw "all object length: expected 'a' to be a number"
-
-  it "fails not to have all elements equal to 1", ->
-    (() -> nonNumLengthObject.should.all.equal 1).
-      should.throw "all object length: expected 'a' to be a number"
+      should.throw
 
 
 describe "an empty array's elements", ->


### PR DESCRIPTION
Fixes #24 

Added two tests to confirm the behaviour for core Chai's `should.have.all.keys` works.

Modified the tests for `should.all.equal` on objects, since we now defer to the original method in this case.

I couldn't figure out the best way of doing this, but this seems to work. I'm happy to accept improvements/changes :)